### PR TITLE
Eit updates+charset fixes+multisteam fixes+multistream updates

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+Changes between 3.2 and -next
+-----------------------------
+  * Add support for getting EIT present/following for chosen service in dvblastctl
+  * Add support for getting EIT schedule for chosen service in dvblastctl
+
 Changes between 3.1 and 3.2:
 ----------------------------
   * Fix HEVC support

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ Changes between 3.2 and -next
 -----------------------------
   * Add support for getting EIT present/following for chosen service in dvblastctl
   * Add support for getting EIT schedule for chosen service in dvblastctl
+  * Switch default string charset to UTF-8//IGNORE
 
 Changes between 3.1 and 3.2:
 ----------------------------

--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,7 @@ Changes between 3.2 and -next
   * Switch default string charset to UTF-8//IGNORE
   * Add --system-charset/-j option to dvblastctl
   * Add --timeout/-t option to dvblastctl and set default to 15 seconds
+  * Add --lnb-type universal|old-sky option to dvblast
 
 Changes between 3.1 and 3.2:
 ----------------------------

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@ Changes between 3.2 and -next
   * Add support for getting EIT present/following for chosen service in dvblastctl
   * Add support for getting EIT schedule for chosen service in dvblastctl
   * Switch default string charset to UTF-8//IGNORE
+  * Add --system-charset/-j option to dvblastctl
 
 Changes between 3.1 and 3.2:
 ----------------------------

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,7 @@ Changes between 3.2 and -next
   * Add support for getting EIT schedule for chosen service in dvblastctl
   * Switch default string charset to UTF-8//IGNORE
   * Add --system-charset/-j option to dvblastctl
+  * Add --timeout/-t option to dvblastctl and set default to 15 seconds
 
 Changes between 3.1 and 3.2:
 ----------------------------

--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,8 @@ Changes between 3.2 and -next
   * Add --system-charset/-j option to dvblastctl
   * Add --timeout/-t option to dvblastctl and set default to 15 seconds
   * Add --lnb-type universal|old-sky option to dvblast
+  * Add support for multistream-id calculation using --multistream-id-pls-mode,
+    --multistream-id-pls-code and --multistream-id-is-id options
 
 Changes between 3.1 and 3.2:
 ----------------------------

--- a/comm.h
+++ b/comm.h
@@ -23,7 +23,7 @@
 #include <bitstream/mpeg/psi.h>
 
 #define COMM_HEADER_SIZE 8
-#define COMM_BUFFER_SIZE (COMM_HEADER_SIZE + ((PSI_PRIVATE_MAX_SIZE + PSI_HEADER_SIZE) * (PSI_TABLE_MAX_SECTIONS / 2)))
+#define COMM_BUFFER_SIZE (COMM_HEADER_SIZE + ((PSI_PRIVATE_MAX_SIZE + PSI_HEADER_SIZE) * PSI_TABLE_MAX_SECTIONS))
 #define COMM_HEADER_MAGIC 0x49
 
 #define COMM_MAX_MSG_CHUNK 4096
@@ -47,6 +47,8 @@ typedef enum {
     CMD_GET_PID             = 16, /* arg: pid (uint16_t) */
     CMD_MMI_SEND_TEXT       = 17, /* arg: slot, en50221_mmi_object_t */
     CMD_MMI_SEND_CHOICE     = 18, /* arg: slot, en50221_mmi_object_t */
+    CMD_GET_EIT_PF          = 19, /* arg: service_id (uint16_t) */
+    CMD_GET_EIT_SCHEDULE    = 20, /* arg: service_id (uint16_t) */
 } ctl_cmd_t;
 
 typedef enum {
@@ -65,6 +67,8 @@ typedef enum {
     RET_PMT                 = 12,
     RET_PIDS                = 13,
     RET_PID                 = 14,
+    RET_EIT_PF              = 15,
+    RET_EIT_SCHEDULE        = 16,
     RET_HUH                 = 255,
 } ctl_cmd_answer_t;
 

--- a/demux.c
+++ b/demux.c
@@ -3027,7 +3027,6 @@ static void HandleEIT( uint16_t i_pid, uint8_t *p_eit, mtime_t i_dts )
     free(p_sid->pp_eit_sections[i_section]);
     p_sid->pp_eit_sections[i_section] = p_eit;
 
-    eit_print( p_eit, msg_Dbg, NULL, demux_Iconv, NULL, PRINT_TEXT );
     if ( b_print_enabled )
     {
         eit_print( p_eit, demux_Print, NULL,

--- a/demux.c
+++ b/demux.c
@@ -82,11 +82,19 @@ typedef struct ts_pid_t
     struct ev_timer timeout_watcher;
 } ts_pid_t;
 
+struct eit_sections {
+    PSI_TABLE_DECLARE(data);
+};
+
+/* EIT is carried in several separate tables, we need to track each table
+   separately, otherwise one table overwrites sections of another table */
+#define MAX_EIT_TABLES ( EIT_TABLE_ID_SCHED_ACTUAL_LAST - EIT_TABLE_ID_PF_ACTUAL )
+
 typedef struct sid_t
 {
     uint16_t i_sid, i_pmt_pid;
     uint8_t *p_current_pmt;
-    PSI_TABLE_DECLARE(pp_eit_sections);
+    struct eit_sections eit_table[MAX_EIT_TABLES];
 } sid_t;
 
 mtime_t i_wallclock = 0;
@@ -440,7 +448,7 @@ void demux_Open( void )
  *****************************************************************************/
 void demux_Close( void )
 {
-    int i;
+    int i, r;
 
     psi_table_free( pp_current_pat_sections );
     psi_table_free( pp_next_pat_sections );
@@ -461,7 +469,9 @@ void demux_Close( void )
     for ( i = 0; i < i_nb_sids; i++ )
     {
         sid_t *p_sid = pp_sids[i];
-        psi_table_free(p_sid->pp_eit_sections);
+        for ( r = 0; r < MAX_EIT_TABLES; r++ ) {
+            psi_table_free( p_sid->eit_table[r].data );
+        }
         free( p_sid->p_current_pmt );
         free( p_sid );
     }
@@ -1414,11 +1424,17 @@ static void SendSDT( mtime_t i_dts )
 /*****************************************************************************
  * SendEIT
  *****************************************************************************/
+static bool handle_epg( int i_table_id )
+{
+    return (i_table_id == EIT_TABLE_ID_PF_ACTUAL ||
+       (i_table_id >= EIT_TABLE_ID_SCHED_ACTUAL_FIRST &&
+        i_table_id <= EIT_TABLE_ID_SCHED_ACTUAL_LAST));
+}
+
 static void SendEIT( sid_t *p_sid, mtime_t i_dts, uint8_t *p_eit )
 {
     uint8_t i_table_id = psi_get_tableid( p_eit );
-    bool b_epg = i_table_id >= EIT_TABLE_ID_SCHED_ACTUAL_FIRST &&
-                 i_table_id <= EIT_TABLE_ID_SCHED_ACTUAL_LAST;
+    bool b_epg = handle_epg( i_table_id );
     uint16_t i_onid = eit_get_onid(p_eit);
     int i;
 
@@ -2170,8 +2186,13 @@ static void DeleteProgram( uint16_t i_sid, uint16_t i_pid )
     }
     p_sid->i_sid = 0;
     p_sid->i_pmt_pid = 0;
-    psi_table_free(p_sid->pp_eit_sections);
-    psi_table_init(p_sid->pp_eit_sections);
+
+    uint8_t r;
+    for ( r = 0; r < MAX_EIT_TABLES; r++ ) {
+        psi_table_free( p_sid->eit_table[r].data );
+        psi_table_init( p_sid->eit_table[r].data );
+    }
+
 }
 
 /*****************************************************************************
@@ -2262,7 +2283,7 @@ static void HandlePAT( mtime_t i_dts )
     bool b_change = false;
     PSI_TABLE_DECLARE( pp_old_pat_sections );
     uint8_t i_last_section = psi_table_get_lastsection( pp_next_pat_sections );
-    uint8_t i;
+    uint8_t i, r;
 
     if ( psi_table_validate( pp_current_pat_sections ) &&
          psi_table_compare( pp_current_pat_sections, pp_next_pat_sections ) )
@@ -2346,7 +2367,9 @@ static void HandlePAT( mtime_t i_dts )
                 {
                     p_sid = malloc( sizeof(sid_t) );
                     p_sid->p_current_pmt = NULL;
-                    psi_table_init(p_sid->pp_eit_sections);
+                    for ( r = 0; r < MAX_EIT_TABLES; r++ ) {
+                        psi_table_init( p_sid->eit_table[r].data );
+                    }
                     i_nb_sids++;
                     pp_sids = realloc( pp_sids, sizeof(sid_t *) * i_nb_sids );
                     pp_sids[i_nb_sids - 1] = p_sid;
@@ -3009,23 +3032,27 @@ static void HandleEIT( uint16_t i_pid, uint8_t *p_eit, mtime_t i_dts )
         return;
     }
 
-    if ( i_table_id != EIT_TABLE_ID_PF_ACTUAL )
+    bool b_epg = handle_epg( i_table_id );
+    if ( ! b_epg )
         goto out_eit;
 
     /* We do not use psi_table_* primitives as the spec allows for holes in
      * section numbering, and there is no sure way to know whether you have
      * gathered all sections. */
     uint8_t i_section = psi_get_section(p_eit);
-    if (p_sid->pp_eit_sections[i_section] != NULL &&
-        psi_compare(p_sid->pp_eit_sections[i_section], p_eit)) {
+    uint8_t eit_table_id = i_table_id - EIT_TABLE_ID_PF_ACTUAL;
+    if (eit_table_id >= MAX_EIT_TABLES)
+        goto out_eit;
+    if (p_sid->eit_table[eit_table_id].data[i_section] != NULL &&
+        psi_compare(p_sid->eit_table[eit_table_id].data[i_section], p_eit)) {
         /* Identical section. Shortcut. */
-        free(p_sid->pp_eit_sections[i_section]);
-        p_sid->pp_eit_sections[i_section] = p_eit;
+        free(p_sid->eit_table[eit_table_id].data[i_section]);
+        p_sid->eit_table[eit_table_id].data[i_section] = p_eit;
         goto out_eit;
     }
 
-    free(p_sid->pp_eit_sections[i_section]);
-    p_sid->pp_eit_sections[i_section] = p_eit;
+    free(p_sid->eit_table[eit_table_id].data[i_section]);
+    p_sid->eit_table[eit_table_id].data[i_section] = p_eit;
 
     if ( b_print_enabled )
     {
@@ -3037,7 +3064,7 @@ static void HandleEIT( uint16_t i_pid, uint8_t *p_eit, mtime_t i_dts )
 
 out_eit:
     SendEIT( p_sid, i_dts, p_eit );
-    if ( i_table_id != EIT_TABLE_ID_PF_ACTUAL )
+    if ( ! b_epg )
         free( p_eit );
 }
 
@@ -3096,9 +3123,7 @@ static void HandleSection( uint16_t i_pid, uint8_t *p_section, mtime_t i_dts )
         break;
 
     default:
-        if ( i_table_id == EIT_TABLE_ID_PF_ACTUAL ||
-             (i_table_id >= EIT_TABLE_ID_SCHED_ACTUAL_FIRST &&
-              i_table_id <= EIT_TABLE_ID_SCHED_ACTUAL_LAST) )
+        if ( handle_epg( i_table_id ) )
         {
             HandleEIT( i_pid, p_section, i_dts );
             break;

--- a/demux.c
+++ b/demux.c
@@ -3054,7 +3054,7 @@ static void HandleEIT( uint16_t i_pid, uint8_t *p_eit, mtime_t i_dts )
     free(p_sid->eit_table[eit_table_id].data[i_section]);
     p_sid->eit_table[eit_table_id].data[i_section] = p_eit;
 
-    if ( b_print_enabled )
+    if ( b_print_enabled && psi_get_tableid( p_eit ) == EIT_TABLE_ID_PF_ACTUAL )
     {
         eit_print( p_eit, demux_Print, NULL,
                    demux_Iconv, NULL, i_print_type );

--- a/dvb.c
+++ b/dvb.c
@@ -1317,10 +1317,10 @@ static void FrontendSet( bool b_init )
         p->props[FEC_INNER].u.data = GetFECInner(info.caps);
         p->props[FREQUENCY].u.data = FrontendDoDiseqc();
 
-        msg_Dbg( NULL, "tuning DVB-S frontend to f=%d srate=%d inversion=%d fec=%d rolloff=%d modulation=%s pilot=%d mis=%d",
+        msg_Dbg( NULL, "tuning DVB-S frontend to f=%d srate=%d inversion=%d fec=%d rolloff=%d modulation=%s pilot=%d mis=%d /pls-mode: %s (%d) pls-code: %d is-id: %d /",
                  i_frequency, i_srate, i_inversion, i_fec, i_rolloff,
                  psz_modulation == NULL ? "legacy" : psz_modulation, i_pilot,
-                 i_mis );
+                 i_mis, psz_mis_pls_mode, i_mis_pls_mode, i_mis_pls_code, i_mis_is_id );
         break;
 
     case SYS_ATSC:

--- a/dvb.c
+++ b/dvb.c
@@ -916,6 +916,12 @@ static struct dtv_properties dvbs_cmdseq = {
     .props = dvbs_cmdargs
 };
 
+#define IDX_DVBS2_PILOT     6
+#define IDX_DVBS2_ROLLOFF   7
+#define IDX_DVBS2_STREAM_ID 8
+
+/* Commands 0..5 are the same as dvbs_cmdargs */
+/* Commands 6..8 are special for DVB-S2 */
 static struct dtv_property dvbs2_cmdargs[] = {
     { .cmd = DTV_DELIVERY_SYSTEM, .u.data = SYS_DVBS2 },
     { .cmd = DTV_FREQUENCY,       .u.data = 0 },
@@ -923,9 +929,9 @@ static struct dtv_property dvbs2_cmdargs[] = {
     { .cmd = DTV_INVERSION,       .u.data = INVERSION_AUTO },
     { .cmd = DTV_SYMBOL_RATE,     .u.data = 27500000 },
     { .cmd = DTV_INNER_FEC,       .u.data = FEC_AUTO },
-    { .cmd = DTV_PILOT,           .u.data = PILOT_AUTO },
-    { .cmd = DTV_ROLLOFF,         .u.data = ROLLOFF_AUTO },
-    { .cmd = DTV_STREAM_ID,       .u.data = 0 },
+    { .cmd = DTV_PILOT,           .u.data = PILOT_AUTO },   /* idx: 6 */
+    { .cmd = DTV_ROLLOFF,         .u.data = ROLLOFF_AUTO }, /* idx: 7 */
+    { .cmd = DTV_STREAM_ID,       .u.data = 0 },            /* idx: 8 */
     { .cmd = DTV_TUNE },
 };
 static struct dtv_properties dvbs2_cmdseq = {
@@ -1036,10 +1042,8 @@ static struct dtv_properties isdbt_cmdseq = {
 #define FEC_INNER 5
 #define FEC_LP 6
 #define GUARD 7
-#define PILOT 7
 #define TRANSMISSION 8
-#define ROLLOFF 8
-#define MIS 9
+
 #define HIERARCHY 9
 #define PLP_ID 10
 
@@ -1301,9 +1305,9 @@ static void FrontendSet( bool b_init )
         {
             p = &dvbs2_cmdseq;
             p->props[MODULATION].u.data = GetModulation();
-            p->props[PILOT].u.data = GetPilot();
-            p->props[ROLLOFF].u.data = GetRollOff();
-            p->props[MIS].u.data = i_mis;
+            p->props[IDX_DVBS2_PILOT].u.data = GetPilot();
+            p->props[IDX_DVBS2_ROLLOFF].u.data = GetRollOff();
+            p->props[IDX_DVBS2_STREAM_ID].u.data = i_mis;
         }
         else
             p = &dvbs_cmdseq;

--- a/dvb.c
+++ b/dvb.c
@@ -470,44 +470,69 @@ static int FrontendDoDiseqc(void)
 
     fe_tone = b_tone ? SEC_TONE_ON : SEC_TONE_OFF;
 
-    /* Automatic mode. */
-    if ( i_frequency >= 950000 && i_frequency <= 2150000 )
+    if ( strcmp( psz_lnb_type, "universal" ) == 0 )
     {
-        msg_Dbg( NULL, "frequency %d is in IF-band", i_frequency );
-        bis_frequency = i_frequency;
+        /* Automatic mode. */
+        if ( i_frequency >= 950000 && i_frequency <= 2150000 )
+        {
+            msg_Dbg( NULL, "frequency %d is in IF-band", i_frequency );
+            bis_frequency = i_frequency;
+        }
+        else if ( i_frequency >= 2500000 && i_frequency <= 2700000 )
+        {
+            msg_Dbg( NULL, "frequency %d is in S-band", i_frequency );
+            bis_frequency = 3650000 - i_frequency;
+        }
+        else if ( i_frequency >= 3400000 && i_frequency <= 4200000 )
+        {
+            msg_Dbg( NULL, "frequency %d is in C-band (lower)", i_frequency );
+            bis_frequency = 5150000 - i_frequency;
+        }
+        else if ( i_frequency >= 4500000 && i_frequency <= 4800000 )
+        {
+            msg_Dbg( NULL, "frequency %d is in C-band (higher)", i_frequency );
+            bis_frequency = 5950000 - i_frequency;
+        }
+        else if ( i_frequency >= 10700000 && i_frequency < 11700000 )
+        {
+            msg_Dbg( NULL, "frequency %d is in Ku-band (lower)",
+                     i_frequency );
+            bis_frequency = i_frequency - 9750000;
+        }
+        else if ( i_frequency >= 11700000 && i_frequency <= 13250000 )
+        {
+            msg_Dbg( NULL, "frequency %d is in Ku-band (higher)",
+                     i_frequency );
+            bis_frequency = i_frequency - 10600000;
+            fe_tone = SEC_TONE_ON;
+        }
+        else
+        {
+            msg_Err( NULL, "frequency %d is out of any known band",
+                     i_frequency );
+            exit(1);
+        }
     }
-    else if ( i_frequency >= 2500000 && i_frequency <= 2700000 )
+    else if ( strcmp( psz_lnb_type, "old-sky" ) == 0 )
     {
-        msg_Dbg( NULL, "frequency %d is in S-band", i_frequency );
-        bis_frequency = 3650000 - i_frequency;
-    }
-    else if ( i_frequency >= 3400000 && i_frequency <= 4200000 )
-    {
-        msg_Dbg( NULL, "frequency %d is in C-band (lower)", i_frequency );
-        bis_frequency = 5150000 - i_frequency;
-    }
-    else if ( i_frequency >= 4500000 && i_frequency <= 4800000 )
-    {
-        msg_Dbg( NULL, "frequency %d is in C-band (higher)", i_frequency );
-        bis_frequency = 5950000 - i_frequency;
-    }
-    else if ( i_frequency >= 10700000 && i_frequency < 11700000 )
-    {
-        msg_Dbg( NULL, "frequency %d is in Ku-band (lower)",
-                 i_frequency );
-        bis_frequency = i_frequency - 9750000;
-    }
-    else if ( i_frequency >= 11700000 && i_frequency <= 13250000 )
-    {
-        msg_Dbg( NULL, "frequency %d is in Ku-band (higher)",
-                 i_frequency );
-        bis_frequency = i_frequency - 10600000;
-        fe_tone = SEC_TONE_ON;
+         if ( i_frequency >= 11700000 && i_frequency <= 13250000 )
+        {
+            msg_Dbg( NULL, "frequency %d is in Ku-band (higher)",
+                     i_frequency );
+            bis_frequency = i_frequency - 11300000;
+            fe_tone = SEC_TONE_ON;
+        }
+        else
+        {
+            msg_Err( NULL, "frequency %d is out of any known band",
+                     i_frequency );
+            exit(1);
+        }
     }
     else
     {
-        msg_Err( NULL, "frequency %d is out of any known band",
-                 i_frequency );
+        msg_Err( NULL, "lnb-type '%s' is not known. Valid type: universal old-sky",
+                 psz_lnb_type );
         exit(1);
     }
 
@@ -608,8 +633,8 @@ static int FrontendDoDiseqc(void)
 
     msleep(100000); /* ... */
 
-    msg_Dbg( NULL, "configuring LNB to v=%d p=%d satnum=%x uncommitted=%x",
-             i_voltage, b_tone, i_satnum, i_uncommitted );
+    msg_Dbg( NULL, "configuring LNB to v=%d p=%d satnum=%x uncommitted=%x lnb-type=%s bis_frequency=%d",
+             i_voltage, b_tone, i_satnum, i_uncommitted, psz_lnb_type, bis_frequency );
     return bis_frequency;
 }
 

--- a/dvblast.1
+++ b/dvblast.1
@@ -73,6 +73,9 @@ Frontend frequency. If '\-' is specified instead of a numeric value,
 the frontend will be not be tuned by dvblast and you should use external
 tuning tool (szap) to tune it.
 .TP
+\fB\-8\fR, \fB\-\-lnb\-type\fR universal\|old\-sky
+Choose LNB type. Default: 'universal' - Universal LNB ("Astra" LNB)
+.TP
 \fB\-F\fR, \fB\-\-fec\-inner\fR <FEC>
 Forward Error Correction used by satellite (FEC Inner)
 .br

--- a/dvblast.1
+++ b/dvblast.1
@@ -110,11 +110,23 @@ Port number for uncommitted DiSEqC switch (0: no uncommitted DiSEqC swtich, 1\-1
 \fB\-K\fR, \fB\-\-fec-lp\fR
 DVB-T low priority FEC (default auto)
 .TP
-\fB\-1\fR, \fB\-\-delsys\fR <delivery_system>
+\fB\-5\fR, \fB\-\-delsys\fR <delivery_system>
 Select delivery system. Possible values: DVBS|DVBS2|DVBC_ANNEX_A|DVBT|ATSC (default guessed)
 .TP
-\fB\-5\fR, \fB\-\-multistream\-id\fR <stream_id>
-Set stream ID for multistream capable transponders. Value: 0-255 (default: 0)
+\fB\-1\fR, \fB\-\-multistream\-id\fR <stream_id>
+Set stream ID for multistream capable transponders. Value: 0-2147483648 (default: 0)
+.TP
+\fB\-\-multistream\-id\-pls\-mode\fR <ROOT|GOLD|COMBO>
+Set PLS mode used in multistream-id calculation. Possible values are: ROOT GOLD and COMBO (default: ROOT).
+If this option is set multistream-id option is overwritten.
+.TP
+\fB\-\-multistream\-id\-pls\-code\fR <0-262143>
+Set PLS code used in multistream-id calculation. Possible values are in range 0..262143 (default: 0).
+If this option is set multistream-id option is overwritten.
+.TP
+\fB\-\-multistream\-id\-is\-id\fR <0-255>
+Set IS id used in multistream-id calculation. Possible values are in range 0..255 (default: 0).
+If this option is set multistream-id option is overwritten.
 .TP
 \fB\-l\fR, \fB\-\-logger\fR
 Send messages to syslog instead of stderr

--- a/dvblast.c
+++ b/dvblast.c
@@ -67,6 +67,7 @@ int i_fenum = 0;
 int i_canum = 0;
 char *psz_delsys = NULL;
 int i_frequency = 0;
+char *psz_lnb_type = "universal";
 int dvb_plp_id = 0;
 int i_inversion = -1;
 int i_srate = 27500000;
@@ -644,6 +645,8 @@ void usage()
     msg_Raw( NULL, "  -5 --delsys           delivery system" );
     msg_Raw( NULL, "    DVBS|DVBS2|DVBC_ANNEX_A|DVBT|DVBT2|ATSC|ISDBT|DVBC_ANNEX_B(ATSC-C/QAMB) (default guessed)");
     msg_Raw( NULL, "  -f --frequency        frontend frequency" );
+    msg_Raw( NULL, "  -8 --lnb-type <type>  Set LNB type')" );
+    msg_Raw( NULL, "        universal old-sky (default: universal)");
     msg_Raw( NULL, "  -9 --dvb-plp-id <number> Switch PLP of the DVB-T2 transmission (for Russia special)" );
     msg_Raw( NULL, "  -F --fec-inner        Forward Error Correction (FEC Inner)");
     msg_Raw( NULL, "    DVB-S2 0|12|23|34|35|56|78|89|910|999 (default auto: 999)");
@@ -730,7 +733,7 @@ int main( int i_argc, char **pp_argv )
         usage();
 
     /*
-     * The only short options left are: 48
+     * The only short options left are: 4
      * Use them wisely.
      */
     static const struct option long_options[] =
@@ -745,6 +748,7 @@ int main( int i_argc, char **pp_argv )
         { "delsys",          required_argument, NULL, '5' },
         { "dvb-plp-id",      required_argument, NULL, '9' },
         { "frequency",       required_argument, NULL, 'f' },
+        { "lnb-type",        required_argument, NULL, '8' },
         { "fec-inner",       required_argument, NULL, 'F' },
         { "rolloff",         required_argument, NULL, 'R' },
         { "symbol-rate",     required_argument, NULL, 's' },
@@ -888,6 +892,10 @@ int main( int i_argc, char **pp_argv )
             msg_Err( NULL, "DVBlast is compiled without DVB support.");
             exit(1);
 #endif
+            break;
+
+        case '8':
+            psz_lnb_type = optarg;
             break;
 
         case 'F':

--- a/dvblast.c
+++ b/dvblast.c
@@ -92,7 +92,7 @@ int b_select_pmts = 0;
 int b_random_tsid = 0;
 char *psz_udp_src = NULL;
 int i_asi_adapter = 0;
-const char *psz_native_charset = "UTF-8";
+const char *psz_native_charset = "UTF-8//IGNORE";
 print_type_t i_print_type = PRINT_TEXT;
 bool b_print_enabled = false;
 FILE *print_fh;
@@ -114,7 +114,7 @@ static mtime_t i_latency_global = DEFAULT_OUTPUT_LATENCY;
 static mtime_t i_retention_global = DEFAULT_MAX_RETENTION;
 static int i_ttl_global = 64;
 
-static const char *psz_dvb_charset = "UTF-8";
+static const char *psz_dvb_charset = "UTF-8//IGNORE";
 static iconv_t conf_iconv = (iconv_t)-1;
 static uint16_t i_network_id = 0xffff;
 static dvb_string_t network_name;
@@ -697,8 +697,8 @@ void usage()
     msg_Raw( NULL, "Misc:" );
     msg_Raw( NULL, "  -h --help             display this full help" );
     msg_Raw( NULL, "  -i --priority <RT priority>" );
-    msg_Raw( NULL, "  -j --system-charset   character set used for printing messages (default UTF-8)" );
-    msg_Raw( NULL, "  -J --dvb-charset      character set used in output DVB tables (default UTF-8)" );
+    msg_Raw( NULL, "  -j --system-charset   character set used for printing messages (default UTF-8//IGNORE)" );
+    msg_Raw( NULL, "  -J --dvb-charset      character set used in output DVB tables (default UTF-8//IGNORE)" );
     msg_Raw( NULL, "  -l --logger           use syslog for logging messages instead of stderr" );
     msg_Raw( NULL, "  -g --logger-ident     program name that will be used in syslog messages" );
     msg_Raw( NULL, "  -x --print            print interesting events on stdout in a given format" );

--- a/dvblast.h
+++ b/dvblast.h
@@ -342,6 +342,8 @@ uint8_t *demux_get_current_packed_CAT( unsigned int *pi_pack_size );
 uint8_t *demux_get_current_packed_NIT( unsigned int *pi_pack_size );
 uint8_t *demux_get_current_packed_SDT( unsigned int *pi_pack_size );
 uint8_t *demux_get_packed_PMT( uint16_t service_id, unsigned int *pi_pack_size );
+uint8_t *demux_get_packed_EIT_pf( uint16_t service_id, unsigned int *pi_pack_size );
+uint8_t *demux_get_packed_EIT_schedule( uint16_t service_id, unsigned int *pi_pack_size );
 void demux_get_PID_info( uint16_t i_pid, uint8_t *p_data );
 void demux_get_PIDS_info( uint8_t *p_data );
 

--- a/dvblast.h
+++ b/dvblast.h
@@ -221,6 +221,7 @@ extern int i_canum;
 extern char *psz_delsys;
 extern int i_dvr_buffer_size;
 extern int i_frequency;
+extern char *psz_lnb_type;
 extern int i_srate;
 extern int i_satnum;
 extern int i_uncommitted;

--- a/dvblast.h
+++ b/dvblast.h
@@ -233,7 +233,15 @@ extern int i_bandwidth;
 extern int i_inversion;
 extern char *psz_modulation;
 extern int i_pilot;
-extern int i_mis;
+
+/* Multistream settings */
+extern int i_mis;          /* Calculated from the three settings bellow, if they are set */
+extern char *psz_mis_pls_mode; /* ROOT, GOLD, COMBO */
+extern int i_mis_pls_mode; /* ROOT - 0, GOLD - 1, COMBO - 2 */
+extern int i_mis_pls_code; /* 0 .. 262143 */
+extern int i_mis_is_id;    /* 0 .. 255 */
+#define calc_multistream_id( pls_mode, pls_code, is_id ) ( pls_mode << 26 | pls_code << 8 | is_id )
+
 extern int i_fec_lp;
 extern int i_guard;
 extern int i_transmission;

--- a/dvblastctl.c
+++ b/dvblastctl.c
@@ -358,6 +358,7 @@ void usage()
     printf("Usage: dvblastctl -r <remote socket> [-x <text|xml>] [cmd]\n");
     printf("Options:\n");
     printf("  -r --remote-socket <name>       Set socket name to <name>.\n" );
+    printf("  -j --system-charset <name>      Character set used for output (default UTF-8//IGNORE)\n" );
     printf("  -x --print <text|xml>           Choose output format for info commands.\n" );
     printf("Control commands:\n");
     printf("  reload                          Reload configuration.\n");
@@ -408,18 +409,23 @@ int main( int i_argc, char **ppsz_argv )
         static const struct option long_options[] =
         {
             {"remote-socket", required_argument, NULL, 'r'},
+            {"system-charset", required_argument, NULL, 'j'},
             {"print", required_argument, NULL, 'x'},
             {"help", no_argument, NULL, 'h'},
             {0, 0, 0, 0}
         };
 
-        if ( (c = getopt_long(i_argc, ppsz_argv, "r:x:h", long_options, NULL)) == -1 )
+        if ( (c = getopt_long(i_argc, ppsz_argv, "r:x:j:h", long_options, NULL)) == -1 )
             break;
 
         switch ( c )
         {
         case 'r':
             psz_srv_socket = optarg;
+            break;
+
+        case 'j':
+            psz_native_charset = optarg;
             break;
 
         case 'x':

--- a/dvblastctl.c
+++ b/dvblastctl.c
@@ -116,7 +116,7 @@ static char *iconv_append_null(const char *p_string, size_t i_length)
     return psz_string;
 }
 
-const char *psz_native_charset = "UTF-8";
+const char *psz_native_charset = "UTF-8//IGNORE";
 
 char *psi_iconv(void *_unused, const char *psz_encoding,
                   char *p_string, size_t i_length)


### PR DESCRIPTION
I'm submitting one pull request with all the things I've worked on in the past several months. The code is in production now and there are no observed problems with it. All functionalities are implemented as separate commits for easier reviewing. This pull request adds several functionalities to dvblast and also fixes DVB mutlistream support to actually work:

* Added support for getting EIT present/following for chosen service in dvblastctl
* Added support for getting EIT schedule for chosen service in dvblastctl
* Disabled printing of EIT to not overwhelm the output with logging
* Switched default string charset to UTF-8//IGNORE
* Added --system-charset/-j option to dvblastctl
* Added --timeout/-t option to dvblastctl and set default to 15 seconds
* Added --lnb-type universal|old-sky option to dvblast
* Added support for multistream-id calculation using --multistream-id-pls-mode, --multistream-id-pls-code and --multistream-id-is-id options
